### PR TITLE
Deploy on all merges to master

### DIFF
--- a/.drydock/blocks/Dockerfile.build
+++ b/.drydock/blocks/Dockerfile.build
@@ -1,6 +1,6 @@
 FROM golang:1.8.3 as build
-ARG TAG
-ARG GITCOMMIT
+ARG RELEASE
+ARG SHA
 ARG BUILT
 WORKDIR /go/src/github.com/autonomy/devise
 RUN apt-get update
@@ -14,4 +14,4 @@ COPY ./ ./
 RUN protoc -I api api/api.proto \
       --go_out=plugins=grpc:api \
       --plugin=protoc-gen-grpc-java=/bin/protoc-gen-grpc-java --grpc-java_out=api
-RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -ldflags "-X \"github.com/autonomy/devise/cli.Tag=${TAG}\" -X \"github.com/autonomy/devise/cli.GitCommit=${GITCOMMIT}\" -X \"github.com/autonomy/devise/cli.Built=${BUILT}\""
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -ldflags "-X \"github.com/autonomy/devise/cli.Release=${RELEASE}\" -X \"github.com/autonomy/devise/cli.SHA=${SHA}\" -X \"github.com/autonomy/devise/cli.Built=${BUILT}\""

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,13 @@ before_install:
 
 script:
   - make init
-  - if [ -z ${TRAVIS_TAG} ];then make; else make TAG=${TRAVIS_TAG}; fi
+  - if [ -z ${TRAVIS_TAG} ];then make; else make RELEASE=${TRAVIS_TAG}; fi
 
 deploy:
   provider: script
   script: scripts/deploy.sh ${TRAVIS_TAG}
   skip_cleanup: true
   on:
-    tags: true
     branch: master
 
 after_success:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,8 +16,8 @@
 [[projects]]
   name = "github.com/aokoli/goutils"
   packages = ["."]
-  revision = "45307ec16e3cd47cd841506c081f7afd8237d210"
-  version = "1.0.0"
+  revision = "3391d3790d23d03408670993e957e8f408993c34"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/dgrijalva/jwt-go"
@@ -29,7 +29,7 @@
   name = "github.com/fatih/structs"
   packages = ["."]
   revision = "a720dfa8df582c51dee1b36feabb906bde1588bd"
-  version = "v1.0"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -215,13 +215,13 @@
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["acme","acme/autocert","pbkdf2","scrypt"]
-  revision = "7e9105388ebff089b3f99f0ef676ea55a6da3a7e"
+  revision = "e1a4589e7d3ea14a3352255d04b6f1a418845e5e"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
-  revision = "48359f4f600b3a2d5cf657458e3f940021631a56"
+  revision = "da118f7b8e5954f39d0d2130ab35d4bf0e3cb344"
 
 [[projects]]
   branch = "master"
@@ -242,10 +242,10 @@
   revision = "d80a6e20e776b0b17a324d0ba1ab50a39c8e8944"
 
 [[projects]]
+  branch = "master"
   name = "google.golang.org/grpc"
   packages = [".","codes","credentials","grpclb/grpc_lb_v1","grpclog","internal","keepalive","metadata","naming","peer","reflection","reflection/grpc_reflection_v1alpha","stats","status","tap","transport"]
-  revision = "d2e1b51f33ff8c5e4a15560ff049d200e83726c5"
-  version = "v1.3.0"
+  revision = "2739967807cc0e3199513569f58fda34252ad65e"
 
 [[projects]]
   branch = "v2"
@@ -256,6 +256,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7815974ec1ef09a0dc6a7e4fc37f4542808b2f58c6c0d881c34c5df603a5e878"
+  inputs-digest = "f5510f9e949e6fdcd86f8e2f49b9f5ac4289ddd722a7250fa8158e2e7b673de2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,9 +19,10 @@
 ## or in a dependency.
 # ignored = ["github.com/user/project/badpkg"]
 
-## Dependencies define constraints on dependent projects. They are respected by
+## Constraints are rules for how directly imported projects
+## may be incorporated into the depgraph. They are respected by
 ## dep whether coming from the Gopkg.toml of the current project or a dependency.
-# [[dependencies]]
+# [[constraint]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
@@ -41,12 +42,12 @@
 # system1-data = "value that is used by a system"
 # system2-data = "value that is used by another system"
 
-## Overrides have the same structure as [[dependencies]], but supersede all
-## [[dependencies]] declarations from all projects. Only the current project's
-## [[overrides]] are applied.
+## Overrides have the same structure as [[constraint]], but supersede all
+## [[constraint]] declarations from all projects. Only [[override]] from
+## the current project's are applied.
 ##
 ## Overrides are a sledgehammer. Use them only as a last resort.
-# [[overrides]]
+# [[override]]
 ## Required: the root import path of the project being constrained.
 # name = "github.com/user/project"
 #
@@ -65,18 +66,46 @@
 
 
 
-[[dependencies]]
+[[constraint]]
+  name = "github.com/Masterminds/sprig"
+  version = "2.12.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/golang/protobuf"
+
+[[constraint]]
+  name = "github.com/hashicorp/vault"
+  version = "0.7.2"
+
+[[constraint]]
   branch = "master"
   name = "github.com/inconshreveable/mousetrap"
 
-[[dependencies]]
+[[constraint]]
+  name = "github.com/labstack/echo"
+  version = "3.1.0"
+
+[[constraint]]
   branch = "master"
   name = "github.com/mitchellh/go-homedir"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/spf13/cobra"
 
-[[dependencies]]
+[[constraint]]
   branch = "master"
   name = "github.com/spf13/viper"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/net"
+
+[[constraint]]
+  branch = "master"
+  name = "google.golang.org/grpc"
+
+[[constraint]]
+  branch = "v2"
+  name = "gopkg.in/yaml.v2"

--- a/Makefile
+++ b/Makefile
@@ -3,27 +3,29 @@ BUILDDEPS := \
 	github.com/golang/dep/cmd/dep \
 	github.com/autonomy/drydock
 
+SHA := $(shell if [ -z "$$(git status --porcelain)" ]; then git rev-parse --short HEAD; else echo "dirty"; fi)
+BUILT := $(shell date)
+
 NAMESPACE := autonomy
 NAME := devise
-TAG ?= develop
-IMAGE := ${NAMESPACE}/${NAME}:${TAG}
-
-GITCOMMIT := $(shell if [ -z "$$(git status --porcelain)" ]; then git rev-parse --short HEAD; else echo "dirty"; fi)
-BUILT := $(shell date)
+RELEASE ?= edge
+IMAGE := ${NAMESPACE}/${NAME}:${SHA}
+IMAGE_RELEASE := ${NAMESPACE}/${NAME}:${RELEASE}
+IMAGE_LATEST := ${NAMESPACE}/${NAME}:latest
 
 
 all: clean vendor
 	@drydock build --template test -- \
 		--tag ${IMAGE} \
-		--build-arg TAG="${TAG}" \
-		--build-arg GITCOMMIT="${GITCOMMIT}" \
+		--build-arg RELEASE="${RELEASE}" \
+		--build-arg SHA="${SHA}" \
 		--build-arg BUILT="${BUILT}" \
 		.
 	@docker run --rm -it --volume $(shell pwd):/out ${IMAGE} cp coverage.txt /out
 	@drydock build --template $@ -- \
 		--tag ${IMAGE} \
-		--build-arg TAG="${TAG}" \
-		--build-arg GITCOMMIT="${GITCOMMIT}" \
+		--build-arg RELEASE="${RELEASE}" \
+		--build-arg SHA="${SHA}" \
 		--build-arg BUILT="${BUILT}" \
 		.
 
@@ -40,11 +42,11 @@ vendor:
 
 .PHONY: build
 build: vendor
-	@echo [Building Devise ${TAG}-${GITCOMMIT}]
+	@echo [Building Devise ${RELEASE}-${SHA}]
 	@drydock build --template $@ -- \
 		--tag ${IMAGE}-$@ \
-		--build-arg TAG="${TAG}" \
-		--build-arg GITCOMMIT="${GITCOMMIT}" \
+		--build-arg RELEASE="${RELEASE}" \
+		--build-arg SHA="${SHA}" \
 		--build-arg BUILT="" \
 		.
 
@@ -53,8 +55,8 @@ test: vendor
 	@echo [Running tests]
 	@drydock build --template $@ -- \
 		--tag ${IMAGE}-$@ \
-		--build-arg TAG="${TAG}" \
-		--build-arg GITCOMMIT="${GITCOMMIT}" \
+		--build-arg RELEASE="${RELEASE}" \
+		--build-arg SHA="${SHA}" \
 		--build-arg BUILT="" \
 		.
 
@@ -63,8 +65,8 @@ image: vendor
 	@echo [Building ${IMAGE}]
 	@drydock build --template $@ -- \
 		--tag ${IMAGE} \
-		--build-arg TAG="${TAG}" \
-		--build-arg GITCOMMIT="${GITCOMMIT}" \
+		--build-arg RELEASE="${RELEASE}" \
+		--build-arg SHA="${SHA}" \
 		--build-arg BUILT="" \
 		.
 
@@ -79,11 +81,28 @@ api: build
 
 # TODO: docs
 
+# TODO: Verify that $RELEASE is of the format vMAJOR.MINOR.PATCH*
 .PHONY: push
 push:
-	@echo [Pushing ${IMAGE}]
-	@docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}";
-	@docker push ${IMAGE};
+	@echo [Tagging ${IMAGE} as ${IMAGE_LATEST}]
+	@docker tag ${IMAGE} ${IMAGE_LATEST}
+	@echo [Tagging ${IMAGE} as ${IMAGE_RELEASE}]
+	@docker tag ${IMAGE} ${IMAGE_RELEASE}
+	@docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+ifneq (${RELEASE},develop)
+	@echo [Pushing ${NAMESPACE}/${NAME}:$(shell echo $${RELEASE:1})]
+	@docker push ${NAMESPACE}/${NAME}:$(shell echo $${RELEASE:1})
+else
+	@echo Tag is 'develop', not pushing ...
+endif
+ifneq (${SHA},dirty)
+	@echo [Pushing ${IMAGE_LATEST}]
+	@docker push ${IMAGE_LATEST}
+	@echo [Pushing ${IMAGE_SHA}]
+	@docker push ${IMAGE_SHA}
+else
+	@echo Git commit is 'dirty', not pushing ...
+endif
 
 .PHONY: run
 run: image stop

--- a/cli/version.go
+++ b/cli/version.go
@@ -8,26 +8,26 @@ import (
 )
 
 var (
-	// Tag is set at build time.
-	Tag string
-	// GitCommit is set at build time.
-	GitCommit string
+	// Release is set at build time.
+	Release string
+	// SHA is set at build time.
+	SHA string
 	// Built is set at build time.
 	Built string
 )
 
 const versionTemplate = `Devise:
-		Tag:         {{ .Tag | printf "%s" }}
-		Git commit:  {{ .GitCommit | printf "%s" }}
-		Built:       {{ .Built | printf "%s" }}
-		Go version:  {{ .GoVersion | printf "%s" }}
-		OS/Arch:     {{ .Os | printf "%s" }}/{{ .Arch | printf "%s" }}
+		Release:     {{ .Release }}
+		SHA:         {{ .SHA }}
+		Built:       {{ .Built }}
+		Go version:  {{ .GoVersion }}
+		OS/Arch:     {{ .Os }}/{{ .Arch }}
 `
 
 // Version contains verbose version information.
 type Version struct {
-	Tag       string
-	GitCommit string
+	Release   string
+	SHA       string
 	Built     string
 	GoVersion string
 	Os        string
@@ -37,8 +37,8 @@ type Version struct {
 // PrintLongVersion prints verbose version information.
 func PrintLongVersion() {
 	v := Version{
-		Tag:       Tag,
-		GitCommit: GitCommit,
+		Release:   Release,
+		SHA:       SHA,
 		GoVersion: runtime.Version(),
 		Os:        runtime.GOOS,
 		Arch:      runtime.GOARCH,
@@ -59,7 +59,7 @@ func PrintLongVersion() {
 	fmt.Println(wr.String())
 }
 
-// PrintShortVersion prints the tag and git commit.
+// PrintShortVersion prints the release and sha.
 func PrintShortVersion() {
-	fmt.Println(fmt.Sprintf("Devise %s-%s", Tag, GitCommit))
+	fmt.Println(fmt.Sprintf("Devise %s-%s", Release, SHA))
 }


### PR DESCRIPTION
This PR will cause all merges to master to deploy an image. The logic is that all merges to master should be consumable. To that end, the `Makefile` will now tag the build with `latest`, the git commit, and the git tag if it is found. Additionally, it brings a minor refactor in the version command.